### PR TITLE
Add TUS_PORT to override x-forwarded-port in generateUrl function

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -122,6 +122,7 @@ type StorageConfigType = {
   tracingFeatures?: {
     upload: boolean
   }
+  tusPort?: string
 }
 
 function getOptionalConfigFromEnv(key: string, fallback?: string): string | undefined {
@@ -251,6 +252,7 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
     ),
     tusUseFileVersionSeparator:
       getOptionalConfigFromEnv('TUS_USE_FILE_VERSION_SEPARATOR') === 'true',
+    tusPort: getOptionalConfigFromEnv('TUS_PORT'),
 
     // S3 Protocol
     s3ProtocolEnabled: getOptionalConfigFromEnv('S3_PROTOCOL_ENABLED') !== 'false',

--- a/src/http/routes/tus/lifecycle.ts
+++ b/src/http/routes/tus/lifecycle.ts
@@ -10,7 +10,7 @@ import { UploadId } from '@storage/protocols/tus'
 
 import { getConfig } from '../../../config'
 
-const { storageS3Bucket, tusPath, requestAllowXForwardedPrefix } = getConfig()
+const { storageS3Bucket, tusPath, requestAllowXForwardedPrefix, tusPort } = getConfig()
 const reExtractFileID = /([^/]+)\/?$/
 
 export const SIGNED_URL_SUFFIX = '/sign'
@@ -102,15 +102,13 @@ export function generateUrl(
   const isSigned = req.url?.endsWith(SIGNED_URL_SUFFIX)
   const fullPath = isSigned ? `${basePath}${SIGNED_URL_SUFFIX}` : basePath
 
-  if (req.headers['x-forwarded-host']) {
-    const port = req.headers['x-forwarded-port']
+  const port = tusPort || req.headers['x-forwarded-port']
 
-    if (typeof port === 'string' && port && !['443', '80'].includes(port)) {
-      if (!host.includes(':')) {
-        host += `:${req.headers['x-forwarded-port']}`
-      } else {
-        host = host.replace(/:\d+$/, `:${req.headers['x-forwarded-port']}`)
-      }
+  if (typeof port === 'string' && port && !['443', '80'].includes(port)) {
+    if (!host.includes(':')) {
+      host += `:${port}`
+    } else {
+      host = host.replace(/:\d+$/, `:${port}`)
     }
   }
 


### PR DESCRIPTION
Add TUS_PORT to override the x-forwarded-port in the `generateUrl` function.

* **Lifecycle.ts**
  - Import `tusPort` from the configuration.
  - Check for `TUS_PORT` environment variable in `generateUrl` function.
  - Use `TUS_PORT` to set the port in the URL if defined.
  - Fall back to using `x-forwarded-port` header if `TUS_PORT` is not defined.
  - Adjust the host accordingly based on the port.

* **Config.ts**
  - Add `tusPort` to the configuration.
  - Use `TUS_PORT` in the `getConfig` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wasdee/storage/pull/1?shareId=48956fb3-bcb0-4582-8f5b-9d819075cd00).